### PR TITLE
Update functionality to work on deployment

### DIFF
--- a/colour-palettes/.npmrc
+++ b/colour-palettes/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/colour-palettes/server/server.js
+++ b/colour-palettes/server/server.js
@@ -4,7 +4,7 @@ const { getRandomPalette, getPaletteFromColor, getPaletteFromText } = require('.
 
 const app = express();
 app.use(express.json())
-const port = 3001; // Can be any port that's free on your system
+const port = process.env.PORT || 3001; // Can be any port that's free on your system
 
 app.use(cors()); // Use CORS to allow cross-origin requests
 
@@ -19,7 +19,7 @@ app.get('/random-palette', async (req, res) => {
 });
 
 app.listen(port, () => {
-  console.log(`Server running on http://localhost:${port}`);
+  console.log(`Server running on port ${port}`);
 });
 
 app.post('/hex-palette', async (req, res) => {

--- a/colour-palettes/src/components/Inputs.js
+++ b/colour-palettes/src/components/Inputs.js
@@ -44,7 +44,7 @@ export default function Inputs({ onChangePalette }) {
     console.log(phrase);
     if (phrase) {
       try {
-        const response = await fetch('http://localhost:3001/text-palette', {
+        const response = await fetch('https://palette-pioneer-backend.onrender.com/text-palette', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -66,7 +66,7 @@ export default function Inputs({ onChangePalette }) {
 
   const randomPalette = async () => {
     try {
-      const response = await fetch('http://localhost:3001/random-palette');
+      const response = await fetch('https://palette-pioneer-backend.onrender.com/random-palette');
       if (response.ok) {
         const newPalette = await response.json();
         onChangePalette(newPalette);
@@ -91,7 +91,7 @@ export default function Inputs({ onChangePalette }) {
 
   async function hexPalette(RGB_array) {
     try {
-      const response = await fetch('http://localhost:3001/hex-palette', {
+      const response = await fetch('https://palette-pioneer-backend.onrender.com/hex-palette', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
Not using `localhost` anymore!
Note I changed references to the backend `http://localhost:3001` to `https://palette-pioneer-backend.onrender.com`.
The frontend is accessible online at `https://palette-pioneer.netlify.app/`. Note it can still be run locally by running `npm start` in the `colour-palettes` folder and accessing `http://localhost:3000`.